### PR TITLE
Compatibility for Serverless deployments in next.config.js

### DIFF
--- a/examples/nextjs/next.config.js
+++ b/examples/nextjs/next.config.js
@@ -6,4 +6,8 @@ const withTM = require("next-transpile-modules")(
   [path.resolve(__dirname, "../../packages")]
 );
 
-module.exports = withTM();
+// Set target for compatibility with Vercel/Now deployments: 
+// Source: https://github.com/vercel/vercel/blob/master/errors/now-next-no-serverless-pages-built.md
+module.exports = withTM({
+  target: "serverless"
+});


### PR DESCRIPTION
Currently deployment to Vercel yields an error. `"No Serverless Pages Built"`


Implemented change recommended here and successfully deployed: https://github.com/vercel/vercel/blob/master/errors/now-next-no-serverless-pages-built.md

As Vercel/Now.sh maintains NextJS itself, it seems reasonable to support their platform by default.  I haven't found an unexpected issues by adding this flag. 